### PR TITLE
Switch to using domain filtering not log_type (#483)

### DIFF
--- a/include/leveled.hrl
+++ b/include/leveled.hrl
@@ -1,3 +1,5 @@
+-include_lib("kernel/include/logger.hrl").
+
 %%%============================================================================
 %%% File paths
 %%%============================================================================
@@ -81,10 +83,95 @@
 -define(EQC_TIME_BUDGET, 120).
 
 %%%============================================================================
-%%% Helper Function
+%%% Helper Functions
 %%%============================================================================
 
 -define(IS_DEF(Attribute), Attribute =/= undefined).
+
+-define(LOG_LOCATION, #{
+    mfa => {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
+    line => ?LINE,
+    file => ?FILE
+}).
+
+-define(STD_LOG(LogRef, Subs),
+    ?STD_LOG_INT(
+        leveled_log:get_loglevel(LogRef),
+        LogRef,
+        Subs,
+        leveled_log:get_opts()
+    )
+).
+
+%% Erlang apply is used because  a variable list of arguments is provided
+-define(STD_LOG_INT(LogLevel, LogRef, Subs, LogOpts),
+    case
+        logger:allow(LogLevel, ?MODULE) andalso
+            leveled_log:should_i_log(LogLevel, LogRef, LogOpts)
+    of
+        true ->
+            erlang:apply(
+                logger,
+                macro_log,
+                [
+                    ?LOG_LOCATION
+                    | leveled_log:log(LogLevel, LogRef, LogOpts, Subs)
+                ]
+            );
+        false ->
+            ok
+    end
+).
+
+-define(RND_LOG(LogRef, Subs, StartTime, RandomProb),
+    case rand:uniform() < RandomProb of
+        true ->
+            ?TMR_LOG_INT(
+                leveled_log:get_loglevel(LogRef),
+                LogRef,
+                Subs,
+                leveled_log:get_opts(),
+                StartTime
+            );
+        false ->
+            ok
+    end
+).
+
+-define(TMR_LOG(LogRef, Subs, StartTime),
+    ?TMR_LOG_INT(
+        leveled_log:get_loglevel(LogRef),
+        LogRef,
+        Subs,
+        leveled_log:get_opts(),
+        StartTime
+    )
+).
+
+-define(TMR_LOG_INT(LogLevel, LogRef, Subs, LogOpts, StartTime),
+    case
+        logger:allow(LogLevel, ?MODULE) andalso
+            leveled_log:should_i_log(LogLevel, LogRef, LogOpts)
+    of
+        true ->
+            erlang:apply(
+                logger,
+                macro_log,
+                [
+                    ?LOG_LOCATION
+                    | leveled_log:log_timer(
+                        LogLevel,
+                        LogRef,
+                        LogOpts,
+                        Subs,
+                        StartTime
+                    )
+                ]
+            );
+        false ->
+            ok
+    end
+).
 
 -if(?OTP_RELEASE < 26).
 -type dynamic() :: any().

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -787,7 +787,7 @@ book_indexfold(Pid, Bucket, FoldAccT, Range, TermHandling) ->
     % future release this code branch may be removed, and such queries may
     % instead return `error`.  For now null is assumed to be lower than any
     % key
-    leveled_log:log(b0019, [Bucket]),
+    ?STD_LOG(b0019, [Bucket]),
     book_indexfold(Pid, {Bucket, null}, FoldAccT, Range, TermHandling).
 
 -type query() ::
@@ -1377,7 +1377,7 @@ init([Opts]) ->
             % and performance may be unpredictable
             case CacheRatio > 32 of
                 true ->
-                    leveled_log:log(b0020, [PCLMaxSize, ConfiguredCacheSize]);
+                    ?STD_LOG(b0020, [PCLMaxSize, ConfiguredCacheSize]);
                 false ->
                     ok
             end,
@@ -1406,7 +1406,7 @@ init([Opts]) ->
             {Inker, Penciller} = startup(InkerOpts, PencillerOpts0),
 
             NewETS = ets:new(mem, [ordered_set]),
-            leveled_log:log(b0001, [Inker, Penciller]),
+            ?STD_LOG(b0001, [Inker, Penciller]),
             {ok, #state{
                 cache_size = CacheSize,
                 cache_multiple = MaxCacheMultiple,
@@ -1424,7 +1424,7 @@ init([Opts]) ->
             BookieMonitor = erlang:monitor(process, Bookie),
             NewETS = ets:new(mem, [ordered_set]),
             {HeadOnly, Lookup} = leveled_bookie:book_headstatus(Bookie),
-            leveled_log:log(b0002, [Inker, Penciller]),
+            ?STD_LOG(b0002, [Inker, Penciller]),
             {ok, #state{
                 penciller = Penciller,
                 inker = Inker,
@@ -1729,7 +1729,7 @@ handle_call(
 handle_call(destroy, _From, State = #state{is_snapshot = Snp}) when
     Snp == false
 ->
-    leveled_log:log(b0011, []),
+    ?STD_LOG(b0011, []),
     {ok, InkPathList} = leveled_inker:ink_doom(State#state.inker),
     {ok, PCLPathList} = leveled_penciller:pcl_doom(State#state.penciller),
     leveled_monitor:monitor_close(element(1, State#state.monitor)),
@@ -1794,13 +1794,13 @@ handle_info(
     {'DOWN', BookieMonRef, process, BookiePid, Info},
     State = #state{bookie_monref = BookieMonRef, is_snapshot = true}
 ) ->
-    leveled_log:log(b0004, [BookiePid, Info]),
+    ?STD_LOG(b0004, [BookiePid, Info]),
     {stop, normal, State};
 handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(Reason, _State) ->
-    leveled_log:log(b0003, [Reason]).
+    ?STD_LOG(b0003, [Reason]).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -1854,7 +1854,7 @@ push_to_penciller(Penciller, LoadItemList, LedgerCache, ReloadStrategy) ->
         ),
     case length(UpdLedgerCache#ledger_cache.load_queue) of
         N when N > ?LOADING_BATCH ->
-            leveled_log:log(b0006, [UpdLedgerCache#ledger_cache.max_sqn]),
+            ?STD_LOG(b0006, [UpdLedgerCache#ledger_cache.max_sqn]),
             ok =
                 push_to_penciller_loop(
                     Penciller, loadqueue_ledgercache(UpdLedgerCache)
@@ -1990,7 +1990,7 @@ startup(InkerOpts, PencillerOpts) ->
     {ok, Inker} = leveled_inker:ink_start(InkerOpts),
     {ok, Penciller} = leveled_penciller:pcl_start(PencillerOpts),
     LedgerSQN = leveled_penciller:pcl_getstartupsequencenumber(Penciller),
-    leveled_log:log(b0005, [LedgerSQN]),
+    ?STD_LOG(b0005, [LedgerSQN]),
     ReloadStrategy = InkerOpts#inker_options.reload_strategy,
     LoadFun = get_loadfun(),
     BatchFun =
@@ -2001,7 +2001,7 @@ startup(InkerOpts, PencillerOpts) ->
         end,
     InitAccFun =
         fun(FN, CurrentMinSQN) ->
-            leveled_log:log(i0014, [FN, CurrentMinSQN]),
+            ?STD_LOG(i0014, [FN, CurrentMinSQN]),
             []
         end,
     FinalAcc =
@@ -2525,7 +2525,7 @@ return_ledger_keyrange(Tag, Bucket, KeyRange) ->
 maybe_longrunning(SW, Aspect) ->
     case timer:now_diff(os:timestamp(), SW) of
         N when N > ?LONG_RUNNING ->
-            leveled_log:log(b0013, [N, Aspect]);
+            ?STD_LOG(b0013, [N, Aspect]);
         _ ->
             ok
     end.

--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -476,10 +476,10 @@ callback_mode() ->
 
 starting({call, From}, {open_writer, Filename}, State) ->
     leveled_log:save(State#state.log_options),
-    leveled_log:log(cdb01, [Filename]),
+    ?STD_LOG(cdb01, [Filename]),
     {LastPosition, HashTree, LastKey} = open_active_file(Filename),
     {WriteOps, UpdStrategy} = set_writeops(State#state.sync_strategy),
-    leveled_log:log(cdb13, [WriteOps]),
+    ?STD_LOG(cdb13, [WriteOps]),
     {ok, Handle} = file:open(Filename, WriteOps),
     State0 = State#state{
         handle = Handle,
@@ -493,7 +493,7 @@ starting({call, From}, {open_writer, Filename}, State) ->
     {next_state, writer, State0, [{reply, From, ok}, hibernate]};
 starting({call, From}, {open_reader, Filename}, State) ->
     leveled_log:save(State#state.log_options),
-    leveled_log:log(cdb02, [Filename]),
+    ?STD_LOG(cdb02, [Filename]),
     {Handle, Index, LastKey} = open_for_readonly(Filename, false),
     State0 = State#state{
         handle = Handle,
@@ -504,7 +504,7 @@ starting({call, From}, {open_reader, Filename}, State) ->
     {next_state, reader, State0, [{reply, From, ok}, hibernate]};
 starting({call, From}, {open_reader, Filename, LastKey}, State) ->
     leveled_log:save(State#state.log_options),
-    leveled_log:log(cdb02, [Filename]),
+    ?STD_LOG(cdb02, [Filename]),
     {Handle, Index, LastKey} = open_for_readonly(Filename, LastKey),
     State0 = State#state{
         handle = Handle,
@@ -706,7 +706,7 @@ rolling(
     ok = write_top_index_table(Handle, BasePos, IndexList),
     file:close(Handle),
     ok = rename_for_read(FN, NewName),
-    leveled_log:log(cdb03, [NewName]),
+    ?STD_LOG(cdb03, [NewName]),
     ets:delete(State#state.hashtree),
     {NewHandle, Index, LastKey} =
         open_for_readonly(NewName, State#state.last_key),
@@ -720,7 +720,7 @@ rolling(
         true ->
             {next_state, delete_pending, State0, [{reply, From, ok}]};
         false ->
-            leveled_log:log_timer(cdb18, [], SW),
+            ?TMR_LOG(cdb18, [], SW),
             {next_state, reader, State0, [{reply, From, ok}, hibernate]}
     end;
 rolling({call, From}, check_hashtable, _State) ->
@@ -819,7 +819,7 @@ reader(
 ) when
     ?IS_DEF(FN), ?IS_DEF(IO)
 ->
-    leveled_log:log(cdb05, [FN, reader, cdb_ccomplete]),
+    ?STD_LOG(cdb05, [FN, reader, cdb_ccomplete]),
     ok = file:close(IO),
     {stop_and_reply, normal, [{reply, From, {ok, FN}}], State#state{
         handle = undefined
@@ -870,7 +870,7 @@ delete_pending(
 ) when
     ?IS_DEF(FN), ?IS_DEF(IO)
 ->
-    leveled_log:log(cdb05, [FN, delete_pending, cdb_close]),
+    ?STD_LOG(cdb05, [FN, delete_pending, cdb_close]),
     close_pendingdelete(IO, FN, State#state.waste_path),
     {stop_and_reply, normal, [{reply, From, ok}]};
 delete_pending({call, From}, Event, State) ->
@@ -880,7 +880,7 @@ delete_pending(
 ) when
     ?IS_DEF(FN), ?IS_DEF(IO)
 ->
-    leveled_log:log(cdb04, [FN, State#state.delete_point]),
+    ?STD_LOG(cdb04, [FN, State#state.delete_point]),
     close_pendingdelete(IO, FN, State#state.waste_path),
     {stop, normal};
 delete_pending(
@@ -888,7 +888,7 @@ delete_pending(
 ) when
     ?IS_DEF(FN), ?IS_DEF(IO)
 ->
-    leveled_log:log(cdb05, [FN, delete_pending, destroy]),
+    ?STD_LOG(cdb05, [FN, delete_pending, destroy]),
     close_pendingdelete(IO, FN, State#state.waste_path),
     {stop, normal};
 delete_pending(
@@ -906,7 +906,7 @@ delete_pending(
                 ),
             {keep_state_and_data, [?DELETE_TIMEOUT]};
         false ->
-            leveled_log:log(cdb04, [FN, ManSQN]),
+            ?STD_LOG(cdb04, [FN, ManSQN]),
             close_pendingdelete(IO, FN, State#state.waste_path),
             {stop, normal}
     end.
@@ -1058,7 +1058,7 @@ close_pendingdelete(Handle, Filename, WasteFP) ->
         false ->
             % This may happen when there has been a destroy while files are
             % still pending deletion
-            leveled_log:log(cdb21, [Filename])
+            ?STD_LOG(cdb21, [Filename])
     end.
 
 -spec set_writeops(sync | riak_sync | none) ->
@@ -1101,7 +1101,7 @@ open_active_file(FileName) when is_list(FileName) ->
                 {?BASE_POSITION, 0} ->
                     ok;
                 _ ->
-                    leveled_log:log(cdb06, [LastPosition, EndPosition])
+                    ?STD_LOG(cdb06, [LastPosition, EndPosition])
             end,
             {ok, _LastPosition} = file:position(Handle, LastPosition),
             ok = file:truncate(Handle),
@@ -1280,7 +1280,7 @@ hashtable_calc(HashTree, StartPos) ->
     Seq = lists:seq(0, 255),
     SWC = os:timestamp(),
     {IndexList, HashTreeBin} = write_hash_tables(Seq, HashTree, StartPos),
-    leveled_log:log_timer(cdb07, [], SWC),
+    ?TMR_LOG(cdb07, [], SWC),
     {IndexList, HashTreeBin}.
 
 %%%%%%%%%%%%%%%%%%%%
@@ -1292,7 +1292,7 @@ determine_new_filename(Filename) ->
 
 rename_for_read(Filename, NewName) ->
     %% Rename file
-    leveled_log:log(cdb08, [Filename, NewName, filelib:is_file(NewName)]),
+    ?STD_LOG(cdb08, [Filename, NewName, filelib:is_file(NewName)]),
     file:rename(Filename, NewName).
 
 -spec open_for_readonly(string(), term()) ->
@@ -1487,7 +1487,7 @@ scan_over_file(Handle, Position, FilterFun, Output, LastKey) ->
                     % Not interesting that we've nothing to read at base
                     ok;
                 _ ->
-                    leveled_log:log(cdb09, [Position])
+                    ?STD_LOG(cdb09, [Position])
             end,
             % Bring file back to that position
             {ok, Position} = file:position(Handle, {bof, Position}),
@@ -1590,7 +1590,7 @@ safe_read_next(Handle, Length, ReadType) ->
         end
     catch
         error:ReadError ->
-            leveled_log:log(cdb20, [ReadError, Length]),
+            ?STD_LOG(cdb20, [ReadError, Length]),
             false
     end.
 
@@ -1604,11 +1604,11 @@ crccheck(<<CRC:32/integer, Value/binary>>, KeyBin) when is_binary(KeyBin) ->
         CRC ->
             Value;
         _ ->
-            leveled_log:log(cdb10, ["mismatch"]),
+            ?STD_LOG(cdb10, ["mismatch"]),
             false
     end;
 crccheck(_V, _KB) ->
-    leveled_log:log(cdb10, ["size"]),
+    ?STD_LOG(cdb10, ["size"]),
     false.
 
 -spec calc_crc(binary(), binary()) -> integer().
@@ -1710,7 +1710,7 @@ search_hash_table(
                 end,
             case KV of
                 missing ->
-                    leveled_log:log(cdb15, [Hash]),
+                    ?STD_LOG(cdb15, [Hash]),
                     search_hash_table(
                         Handle,
                         {FirstHashPosition, Slot, CycleCount + 1, TotalSlots},
@@ -1765,7 +1765,7 @@ perform_write_hash_tables(Handle, HashTreeBin, StartPos) ->
     ok = file:write(Handle, HashTreeBin),
     {ok, EndPos} = file:position(Handle, cur),
     ok = file:advise(Handle, StartPos, EndPos - StartPos, will_need),
-    leveled_log:log_timer(cdb12, [], SWW),
+    ?TMR_LOG(cdb12, [], SWW),
     ok.
 
 %% Write the top most 255 doubleword entries.  First word is the
@@ -1952,7 +1952,7 @@ write_hash_tables(
     HT_BinList,
     {T1, T2, T3}
 ) ->
-    leveled_log:log(cdb14, [T1, T2, T3]),
+    ?STD_LOG(cdb14, [T1, T2, T3]),
     IL = lists:reverse(IndexList),
     {IL, list_to_binary(lists:reverse(HT_BinList))};
 write_hash_tables(

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -626,7 +626,7 @@ get_tagstrategy(Tag, Strategy) ->
             %% running in head_only mode - so don't warn
             retain;
         false ->
-            leveled_log:log(ic012, [Tag, Strategy]),
+            ?STD_LOG(ic012, [Tag, Strategy]),
             retain
     end.
 

--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -322,12 +322,9 @@ handle_call(stop, _From, State) ->
 
 handle_cast(
     {compact, Checker, InitiateFun, CloseFun, FilterFun, Manifest0},
-    State
+    State = #state{max_run_length = MRL, reload_strategy = RS}
 ) ->
-    leveled_log:log(ic014, [
-        State#state.reload_strategy,
-        State#state.max_run_length
-    ]),
+    ?STD_LOG(ic014, [RS, MRL]),
     % Empty the waste folder
     clear_waste(State),
     SW = os:timestamp(),
@@ -427,7 +424,7 @@ handle_cast(
         {MaxRunLength, State#state.maxrunlength_compactionperc,
             State#state.singlefile_compactionperc},
     {BestRun0, Score} = assess_candidates(Candidates, ScoreParams),
-    leveled_log:log_timer(ic003, [Score, length(BestRun0)], SW),
+    ?TMR_LOG(ic003, [Score, length(BestRun0)], SW),
     case Score > 0.0 of
         true ->
             BestRun1 = sort_run(BestRun0),
@@ -454,7 +451,7 @@ handle_cast(
                     end,
                     BestRun1
                 ),
-            leveled_log:log(ic002, [length(FilesToDelete)]),
+            ?STD_LOG(ic002, [length(FilesToDelete)]),
             ok = CloseFun(FilterServer),
             ok =
                 leveled_inker:ink_clerkcomplete(
@@ -472,7 +469,7 @@ handle_cast(
 ->
     FilesToDelete =
         leveled_imanifest:find_persistedentries(PersistedSQN, ManifestAsList),
-    leveled_log:log(ic007, []),
+    ?STD_LOG(ic007, []),
     ok = leveled_inker:ink_clerkcomplete(Ink, [], FilesToDelete),
     {noreply, State};
 handle_cast({hashtable_calc, HashTree, StartPos, CDBpid}, State) ->
@@ -501,7 +498,7 @@ handle_info(_Info, State) ->
 terminate(normal, _State) ->
     ok;
 terminate(Reason, _State) ->
-    leveled_log:log(ic001, [Reason]).
+    ?STD_LOG(ic001, [Reason]).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -633,12 +630,12 @@ check_single_file(
     Score.
 
 safely_log_filescore([], FN, Score, SW) ->
-    leveled_log:log_timer(ic004, [Score, empty, FN], SW);
+    ?TMR_LOG(ic004, [Score, empty, FN], SW);
 safely_log_filescore(PositionList, FN, Score, SW) ->
     AvgJump =
         (lists:last(PositionList) - lists:nth(1, PositionList)) div
             length(PositionList),
-    leveled_log:log_timer(ic004, [Score, AvgJump, FN], SW).
+    ?TMR_LOG(ic004, [Score, AvgJump, FN], SW).
 
 -spec size_comparison_score(
     list(key_size() | corrupted_test_key_size()),
@@ -801,12 +798,12 @@ score_run(Run, {MaxRunLength, MR_CT, SF_CT}) ->
     Target - RunTotal / length(Run).
 
 print_compaction_run(BestRun, ScoreParams) ->
-    leveled_log:log(
+    ?STD_LOG(
         ic005, [length(BestRun), score_run(BestRun, ScoreParams)]
     ),
     lists:foreach(
         fun(File) ->
-            leveled_log:log(ic006, [File#candidate.filename])
+            ?STD_LOG(ic006, [File#candidate.filename])
         end,
         BestRun
     ).
@@ -906,7 +903,7 @@ get_all_positions([], PositionBatches) ->
 get_all_positions([HeadRef | RestOfBest], PositionBatches) ->
     SrcJournal = HeadRef#candidate.journal,
     Positions = leveled_cdb:cdb_getpositions(SrcJournal, all),
-    leveled_log:log(ic008, [HeadRef#candidate.filename, length(Positions)]),
+    ?STD_LOG(ic008, [HeadRef#candidate.filename, length(Positions)]),
     Batches =
         split_positions_into_batches(
             lists:sort(Positions), SrcJournal, []
@@ -1027,7 +1024,7 @@ write_values(KVCList, CDBopts, Journal0, ManSlice0, PressMethod) ->
                 {SQN, _LK} = leveled_codec:from_journalkey(TK),
                 FP = CDBopts#cdb_options.file_path,
                 FN = leveled_inker:filepath(FP, SQN, compact_journal),
-                leveled_log:log(ic009, [FN]),
+                ?STD_LOG(ic009, [FN]),
                 leveled_cdb:cdb_open_writer(FN, CDBopts);
             _ ->
                 {ok, Journal0}
@@ -1055,9 +1052,9 @@ clear_waste(State) ->
                     case N - calendar:datetime_to_gregorian_seconds(LMD) of
                         LMD_Delta when LMD_Delta >= WRP ->
                             ok = file:delete(WP ++ DelJ),
-                            leveled_log:log(ic010, [WP ++ DelJ]);
+                            ?STD_LOG(ic010, [WP ++ DelJ]);
                         LMD_Delta ->
-                            leveled_log:log(ic011, [WP ++ DelJ, LMD_Delta]),
+                            ?STD_LOG(ic011, [WP ++ DelJ, LMD_Delta]),
                             ok
                     end
                 end,

--- a/src/leveled_imanifest.erl
+++ b/src/leveled_imanifest.erl
@@ -3,6 +3,8 @@
 
 -module(leveled_imanifest).
 
+-include("leveled.hrl").
+
 -export([
     generate_entry/1,
     add_entry/3,
@@ -52,7 +54,7 @@ generate_entry(Journal) ->
             [{StartSQN, NewFN, PidR, LastKey}];
         empty ->
             ok = leveled_cdb:cdb_close(PidR),
-            leveled_log:log(ic013, [NewFN]),
+            ?STD_LOG(ic013, [NewFN]),
             []
     end.
 
@@ -95,7 +97,7 @@ append_lastkey(Manifest, Pid, LastKey) ->
 %% Remove an entry from a manifest (after compaction)
 remove_entry(Manifest, Entry) ->
     {SQN, FN, _PidR, _LastKey} = Entry,
-    leveled_log:log(i0013, [FN]),
+    ?STD_LOG(i0013, [FN]),
     Man0 = lists:keydelete(SQN, 1, to_list(Manifest)),
     from_list(Man0).
 
@@ -152,7 +154,7 @@ to_list(Manifest) ->
 %% loss on rollback.
 reader(SQN, RootPath) ->
     ManifestPath = leveled_inker:filepath(RootPath, manifest_dir),
-    leveled_log:log(i0015, [ManifestPath, SQN]),
+    ?STD_LOG(i0015, [ManifestPath, SQN]),
     {ok, MBin} = file:read_file(
         filename:join(
             ManifestPath,
@@ -182,7 +184,7 @@ writer(Manifest, ManSQN, RootPath) ->
     %% check backwards compatible (so that the reader can read manifests both
     %% with and without a CRC check)
     MBin = term_to_binary(to_list(Manifest), [compressed]),
-    leveled_log:log(i0016, [ManSQN]),
+    ?STD_LOG(i0016, [ManSQN]),
     ok = leveled_util:safe_rename(TmpFN, NewFN, MBin, true),
     GC_SQN = ManSQN - ?MANIFESTS_TO_RETAIN,
     GC_Man = filename:join(
@@ -203,7 +205,7 @@ writer(Manifest, ManSQN, RootPath) ->
 printer(Manifest) ->
     lists:foreach(
         fun({SQN, FN, _PID, _LK}) ->
-            leveled_log:log(i0017, [SQN, FN])
+            ?STD_LOG(i0017, [SQN, FN])
         end,
         to_list(Manifest)
     ).

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -581,7 +581,7 @@ handle_call({fetch, Key, SQN}, _From, State) ->
         {{SQN, Key}, {Value, _IndexSpecs}} ->
             {reply, {ok, Value}, State};
         Other ->
-            leveled_log:log(i0001, [Key, SQN, Other]),
+            ?STD_LOG(i0001, [Key, SQN, Other]),
             {reply, not_present, State}
     end;
 handle_call({get, Key, SQN}, _From, State) ->
@@ -619,7 +619,7 @@ handle_call(
         {Requestor, os:timestamp(), State#state.manifest_sqn}
         | State#state.registered_snapshots
     ],
-    leveled_log:log(i0002, [Requestor, State#state.manifest_sqn]),
+    ?STD_LOG(i0002, [Requestor, State#state.manifest_sqn]),
     {reply,
         {
             State#state.manifest,
@@ -673,7 +673,7 @@ handle_call(roll, _From, State = #state{is_snapshot = Snap}) when
                     State#state.root_path,
                     State#state.manifest_sqn
                 ),
-            leveled_log:log_timer(i0024, [NewSQN], SWroll),
+            ?TMR_LOG(i0024, [NewSQN], SWroll),
             {reply, ok, State#state{
                 journal_sqn = NewSQN,
                 manifest = Manifest1,
@@ -690,7 +690,7 @@ handle_call(
     BackupJFP = filepath(filename:join(BackupPath, ?JOURNAL_FP), journal_dir),
     ok = filelib:ensure_dir(BackupJFP),
     {ok, CurrentFNs} = file:list_dir(BackupJFP),
-    leveled_log:log(i0023, [length(CurrentFNs)]),
+    ?STD_LOG(i0023, [length(CurrentFNs)]),
     BackupFun =
         fun({SQN, FN, PidR, LastKey}, {ManAcc, FTRAcc}) ->
             case SQN < State#state.journal_sqn of
@@ -714,7 +714,7 @@ handle_call(
                         ExtendedBaseFN | FTRAcc
                     ]};
                 false ->
-                    leveled_log:log(i0021, [FN, SQN, State#state.journal_sqn]),
+                    ?STD_LOG(i0021, [FN, SQN, State#state.journal_sqn]),
                     {ManAcc, FTRAcc}
             end
         end,
@@ -728,7 +728,7 @@ handle_call(
     FilesToRemove = lists:subtract(CurrentFNs, FilesToRetain),
     RemoveFun =
         fun(RFN) ->
-            leveled_log:log(i0022, [RFN]),
+            ?STD_LOG(i0022, [RFN]),
             RemoveFile = filename:join(BackupJFP, RFN),
             case filelib:is_regular(RemoveFile) of
                 true ->
@@ -743,16 +743,13 @@ handle_call(
         State#state.manifest_sqn,
         filename:join(BackupPath, ?JOURNAL_FP)
     ),
-    leveled_log:log_timer(
-        i0020,
-        [filename:join(BackupPath, ?JOURNAL_FP), length(BackupManifest)],
-        SW
-    ),
+    BackupJournalPath = filename:join(BackupPath, ?JOURNAL_FP),
+    ?TMR_LOG(i0020, [BackupJournalPath, length(BackupManifest)], SW),
     {reply, ok, State};
 handle_call({check_sqn, LedgerSQN}, _From, State) ->
     case State#state.journal_sqn of
         JSQN when JSQN < LedgerSQN ->
-            leveled_log:log(i0025, [JSQN, LedgerSQN]),
+            ?STD_LOG(i0025, [JSQN, LedgerSQN]),
             {reply, ok, State#state{journal_sqn = LedgerSQN}};
         _JSQN ->
             {reply, ok, State}
@@ -776,12 +773,12 @@ handle_call(
 ->
     case ShutdownType of
         doom ->
-            leveled_log:log(i0018, []);
+            ?STD_LOG(i0018, []);
         close ->
             ok
     end,
-    leveled_log:log(i0005, [ShutdownType]),
-    leveled_log:log(
+    ?STD_LOG(i0005, [ShutdownType]),
+    ?STD_LOG(
         i0006, [State#state.journal_sqn, State#state.manifest_sqn]
     ),
     ok = leveled_iclerk:clerk_stop(State#state.clerk),
@@ -852,12 +849,12 @@ handle_cast({confirm_delete, ManSQN, CDB}, State) ->
     end,
     {noreply, State#state{registered_snapshots = RegisteredSnapshots0}};
 handle_cast({release_snapshot, Snapshot}, State) ->
-    leveled_log:log(i0003, [Snapshot]),
+    ?STD_LOG(i0003, [Snapshot]),
     case lists:keydelete(Snapshot, 1, State#state.registered_snapshots) of
         [] ->
             {noreply, State#state{registered_snapshots = []}};
         Rs ->
-            leveled_log:log(i0004, [length(Rs)]),
+            ?STD_LOG(i0004, [length(Rs)]),
             {noreply, State#state{registered_snapshots = Rs}}
     end;
 handle_cast({log_level, LogLevel}, State) ->
@@ -901,7 +898,7 @@ handle_cast({maybe_defer_shutdown, ShutdownType, From}, State) ->
             % complete_shutdown cast is sent
             case State#state.shutdown_loops of
                 LoopCount when LoopCount > 0 ->
-                    leveled_log:log(i0026, [N]),
+                    ?STD_LOG(i0026, [N]),
                     timer:sleep(?SHUTDOWN_PAUSE div ?SHUTDOWN_LOOPS),
                     gen_server:cast(
                         self(), {maybe_defer_shutdown, ShutdownType, From}
@@ -952,9 +949,9 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(Reason, _State = #state{is_snapshot = Snap}) when Snap == true ->
-    leveled_log:log(i0027, [Reason]);
+    ?STD_LOG(i0027, [Reason]);
 terminate(Reason, _State) ->
-    leveled_log:log(i0028, [Reason]).
+    ?STD_LOG(i0028, [Reason]).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -1036,7 +1033,7 @@ start_from_file(
 %% @doc
 %% Shutdown all files in the manifest
 shutdown_manifest(Manifest) ->
-    leveled_log:log(i0007, []),
+    ?STD_LOG(i0007, []),
     leveled_imanifest:printer(Manifest),
     ManAsList = leveled_imanifest:to_list(Manifest),
     close_allmanifest(ManAsList).
@@ -1116,7 +1113,7 @@ put_object(
                     State#state.root_path,
                     State#state.manifest_sqn
                 ),
-            leveled_log:log_timer(i0008, [], SWroll),
+            ?TMR_LOG(i0008, [], SWroll),
             ok =
                 leveled_cdb:cdb_put(
                     NewJournalP, JournalKey, JournalBin
@@ -1238,13 +1235,13 @@ build_manifest(ManifestFilenames, RootPath, CDBopts) ->
     UpdManifestSQN =
         if
             length(OpenManifest) > length(Manifest) ->
-                leveled_log:log(i0009, []),
+                ?STD_LOG(i0009, []),
                 leveled_imanifest:printer(OpenManifest),
                 NextSQN = ManifestSQN + 1,
                 leveled_imanifest:writer(OpenManifest, NextSQN, RootPath),
                 NextSQN;
             true ->
-                leveled_log:log(i0010, []),
+                ?STD_LOG(i0010, []),
                 leveled_imanifest:printer(OpenManifest),
                 ManifestSQN
         end,
@@ -1269,7 +1266,7 @@ close_allmanifest([H | ManifestT]) ->
 %% Open all the files in the manifets, and updating the manifest with the PIDs
 %% of the opened files
 open_all_manifest([], RootPath, CDBOpts) ->
-    leveled_log:log(i0011, []),
+    ?STD_LOG(i0011, []),
     leveled_imanifest:add_entry(
         [],
         start_new_activejournal(0, RootPath, CDBOpts),
@@ -1302,7 +1299,7 @@ open_all_manifest(Man0, RootPath, CDBOpts) ->
     PendingHeadFN = HeadFN ++ "." ++ ?PENDING_FILEX,
     case filelib:is_file(CompleteHeadFN) of
         true ->
-            leveled_log:log(i0012, [HeadFN]),
+            ?STD_LOG(i0012, [HeadFN]),
             {ok, HeadR} = leveled_cdb:cdb_open_reader(CompleteHeadFN),
             LastKey = {LastSQN, _, _} = leveled_cdb:cdb_lastkey(HeadR),
             ManToHead =

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -22,22 +22,21 @@
 
 -module(leveled_log).
 
--include_lib("kernel/include/logger.hrl").
-
 -export([
-    log/2,
-    log_timer/3,
-    log_randomtimer/4
+    log/4,
+    log_timer/5,
+    should_i_log/3,
+    get_opts/0,
+    get_loglevel/1
 ]).
 
--export([log/5, log_timer/6]).
+-export([log/6, log_timer/7]).
 
 -export([
     set_loglevel/1,
     set_databaseid/1,
     add_forcedlogs/1,
     remove_forcedlogs/1,
-    get_opts/0,
     save/1,
     return_settings/0
 ]).
@@ -53,6 +52,8 @@
 -type log_base() :: #{atom() => {log_level(), binary()}}.
 
 -export_type([log_options/0, log_level/0, log_base/0]).
+
+-define(DOMAIN, [backend, leveled]).
 
 -define(LOG_LEVELS, [debug, info, warning, error, critical]).
 -define(DEFAULT_LOG_LEVEL, error).
@@ -405,6 +406,11 @@ set_databaseid(DBid) when is_integer(DBid) ->
     UpdLO = LO#log_options{database_id = DBid},
     save(UpdLO).
 
+-spec get_loglevel(atom()) -> log_level().
+get_loglevel(LogRef) ->
+    {LogLevel, _LogText} = maps:get(LogRef, ?LOGBASE),
+    LogLevel.
+
 -spec add_forcedlogs(list(atom())) -> ok.
 %% @doc
 %% Add a forced log to the list of forced logs. this will cause the log of this
@@ -458,31 +464,24 @@ return_settings() ->
 %%% Prompt Logs
 %%%============================================================================
 
--spec log(atom(), list()) -> ok.
-log(LogReference, Subs) ->
-    log(LogReference, Subs, ?LOG_LEVELS, ?LOGBASE, backend).
+-spec log(log_level(), atom(), log_options(), list()) -> list().
+log(LogLevel, LogRef, LogOpts, Subs) ->
+    log(LogLevel, LogRef, LogOpts, Subs, ?LOGBASE, ?DOMAIN).
 
--spec log(atom(), list(), list(log_level()), log_base(), atom()) -> ok.
-log(LogRef, Subs, SupportedLevels, LogBase, Tag) ->
-    {LogLevel, Log} = maps:get(LogRef, LogBase),
-    LogOpts = get_opts(),
-    case should_i_log(LogLevel, SupportedLevels, LogRef, LogOpts) of
-        true ->
-            DBid = LogOpts#log_options.database_id,
-            Prefix =
-                log_prefix(LogRef, DBid, self()),
-            Suffix = <<"~n">>,
-            ?LOG(
-                LogLevel,
-                unicode:characters_to_list([Prefix, Log, Suffix]),
-                Subs,
-                #{log_type => Tag}
-            );
-        false ->
-            ok
-    end.
+-spec log(log_level(), atom(), log_options(), list(), log_base(), list(atom())) ->
+    list().
+log(LogLevel, LogRef, LogOpts, Subs, LogBase, Domain) ->
+    {_LogLevel, Log} = maps:get(LogRef, LogBase),
+    DBid = LogOpts#log_options.database_id,
+    Prefix = log_prefix(LogRef, DBid),
+    [
+        LogLevel,
+        unicode:characters_to_list([Prefix, Log]),
+        Subs,
+        #{domain => Domain}
+    ].
 
-should_i_log(LogLevel, Levels, LogRef, LogOpts) ->
+should_i_log(LogLevel, LogRef, LogOpts) ->
     #log_options{log_level = CurLevel, forced_logs = ForcedLogs} = LogOpts,
     case lists:member(LogRef, ForcedLogs) of
         true ->
@@ -492,7 +491,7 @@ should_i_log(LogLevel, Levels, LogRef, LogOpts) ->
                 CurLevel == LogLevel ->
                     true;
                 true ->
-                    is_active_level(Levels, CurLevel, LogLevel)
+                    is_active_level(?LOG_LEVELS, CurLevel, LogLevel)
             end
     end.
 
@@ -500,56 +499,51 @@ is_active_level([L | _], L, _) -> true;
 is_active_level([L | _], _, L) -> false;
 is_active_level([_ | T], C, L) -> is_active_level(T, C, L).
 
--spec log_timer(atom(), list(), erlang:timestamp()) -> ok.
-log_timer(LogReference, Subs, StartTime) ->
-    log_timer(LogReference, Subs, StartTime, ?LOG_LEVELS, ?LOGBASE, backend).
+-spec log_timer(log_level(), atom(), log_options(), list(), erlang:timestamp()) ->
+    list().
+log_timer(LogLevel, LogRef, LogOpts, Subs, StartTime) ->
+    log_timer(
+        LogLevel,
+        LogRef,
+        LogOpts,
+        Subs,
+        StartTime,
+        ?LOGBASE,
+        ?DOMAIN
+    ).
 
 -spec log_timer(
-    atom(), list(), erlang:timestamp(), list(log_level()), log_base(), atom()
+    log_level(),
+    atom(),
+    log_options(),
+    list(),
+    erlang:timestamp(),
+    log_base(),
+    [atom()]
 ) ->
-    ok.
-log_timer(LogRef, Subs, StartTime, SupportedLevels, LogBase, Tag) ->
-    {LogLevel, Log} = maps:get(LogRef, LogBase),
-    LogOpts = get_opts(),
-    case should_i_log(LogLevel, SupportedLevels, LogRef, LogOpts) of
-        true ->
-            DBid = LogOpts#log_options.database_id,
-            Prefix =
-                log_prefix(LogRef, DBid, self()),
-            Suffix = <<"~n">>,
-            Duration = duration_text(StartTime),
-            ?LOG(
-                LogLevel,
-                unicode:characters_to_list([Prefix, Log, Duration, Suffix]),
-                Subs,
-                #{log_type => Tag}
-            );
-        false ->
-            ok
-    end.
+    list().
+log_timer(LogLevel, LogRef, LogOpts, Subs, StartTime, LogBase, Domain) ->
+    {_LogLevel, Log} = maps:get(LogRef, LogBase),
+    DBid = LogOpts#log_options.database_id,
+    Prefix = log_prefix(LogRef, DBid),
+    Duration = duration_text(StartTime),
+    [
+        LogLevel,
+        unicode:characters_to_list([Prefix, Log, Duration]),
+        Subs,
+        #{domain => Domain}
+    ].
 
--spec log_randomtimer(atom(), list(), erlang:timestamp(), float()) -> term().
-log_randomtimer(LogReference, Subs, StartTime, RandomProb) ->
-    R = rand:uniform(),
-    case R < RandomProb of
-        true ->
-            log_timer(LogReference, Subs, StartTime);
-        false ->
-            ok
-    end.
-
--spec log_prefix(atom(), non_neg_integer() | undefined, pid()) ->
+-spec log_prefix(atom(), non_neg_integer() | undefined) ->
     io_lib:chars().
-log_prefix(LogRef, undefined, Pid) ->
-    ["log_ref=", atom_to_list(LogRef), " pid=", pid_to_list(Pid), " "];
-log_prefix(LogRef, DBid, Pid) ->
+log_prefix(LogRef, undefined) ->
+    ["log_ref=", atom_to_list(LogRef), " "];
+log_prefix(LogRef, DBid) ->
     [
         "log_ref=",
         atom_to_list(LogRef),
         " db_id=",
         integer_to_list(DBid),
-        " pid=",
-        pid_to_list(Pid),
         " "
     ].
 
@@ -575,21 +569,14 @@ duration_text(StartTime) ->
 
 -include_lib("eunit/include/eunit.hrl").
 
-should_i_log(LogLevel, Levels, LogRef) ->
-    should_i_log(LogLevel, Levels, LogRef, get_opts()).
-
-log_warning_test() ->
-    ok = log(g0001, [], [warning, error], ?LOGBASE, backend),
-    ok =
-        log_timer(
-            g0001, [], os:timestamp(), [warning, error], ?LOGBASE, backend
-        ).
+should_i_log(LogLevel, LogRef) ->
+    should_i_log(LogLevel, LogRef, get_opts()).
 
 log_wrongkey_test() ->
     ?assertException(
         error,
         {badkey, wrong0001},
-        log(wrong0001, [], [warning, error], ?LOGBASE, backend)
+        log(info, wrong0001, get_opts(), [], ?LOGBASE, [backend, leveled])
     ).
 
 logtimer_wrongkey_test() ->
@@ -599,24 +586,25 @@ logtimer_wrongkey_test() ->
     % function being tested is split across lines, the closing bracket on the
     % next line is not recognised as being covered. We want 100% coverage, so
     % need to write this on one line.
+    Ds = [backend, leveled],
     ?assertException(
         error,
         {badkey, wrong0001},
-        log_timer(wrong0001, [], ST, [warning, error], ?LOGBASE, backend)
+        log_timer(info, wrong0001, get_opts(), [], ST, ?LOGBASE, Ds)
     ).
 
 shouldilog_test() ->
     ok = set_loglevel(debug),
-    ?assertMatch(true, should_i_log(info, ?LOG_LEVELS, g0001)),
+    ?assertMatch(true, should_i_log(info, g0001)),
     ok = set_loglevel(info),
-    ?assertMatch(true, should_i_log(info, ?LOG_LEVELS, g0001)),
+    ?assertMatch(true, should_i_log(info, g0001)),
     ok = add_forcedlogs([g0001]),
     ok = set_loglevel(error),
-    ?assertMatch(true, should_i_log(info, ?LOG_LEVELS, g0001)),
-    ?assertMatch(false, should_i_log(info, ?LOG_LEVELS, g0002)),
+    ?assertMatch(true, should_i_log(info, g0001)),
+    ?assertMatch(false, should_i_log(info, g0002)),
     ok = remove_forcedlogs([g0001]),
     ok = set_loglevel(info),
-    ?assertMatch(false, should_i_log(debug, ?LOG_LEVELS, d0001)).
+    ?assertMatch(false, should_i_log(debug, d0001)).
 
 badloglevel_test() ->
     % Set a bad log level - and everything logs

--- a/src/leveled_monitor.erl
+++ b/src/leveled_monitor.erl
@@ -19,6 +19,8 @@
 
 -behaviour(gen_server).
 
+-include("leveled.hrl").
+
 -export([
     init/1,
     handle_call/3,
@@ -481,7 +483,7 @@ handle_cast({report_stats, bookie_get}, State) ->
             os:timestamp(),
             Timings#bookie_get_timings.sample_start_time
         ) div 1000000,
-    leveled_log:log(
+    ?STD_LOG(
         b0016,
         [
             Timings#bookie_get_timings.sample_count,
@@ -499,7 +501,7 @@ handle_cast({report_stats, bookie_head}, State) ->
             os:timestamp(),
             Timings#bookie_head_timings.sample_start_time
         ) div 1000000,
-    leveled_log:log(
+    ?STD_LOG(
         b0018,
         [
             Timings#bookie_head_timings.sample_count,
@@ -520,7 +522,7 @@ handle_cast({report_stats, bookie_put}, State) ->
             os:timestamp(),
             Timings#bookie_put_timings.sample_start_time
         ) div 1000000,
-    leveled_log:log(
+    ?STD_LOG(
         b0015,
         [
             Timings#bookie_put_timings.sample_count,
@@ -539,7 +541,7 @@ handle_cast({report_stats, bookie_snap}, State) ->
             os:timestamp(),
             Timings#bookie_snap_timings.sample_start_time
         ) div 1000000,
-    leveled_log:log(
+    ?STD_LOG(
         b0017,
         [
             Timings#bookie_snap_timings.sample_count,
@@ -556,7 +558,7 @@ handle_cast({report_stats, pcl_fetch}, State) ->
             os:timestamp(),
             Timings#pcl_fetch_timings.sample_start_time
         ) div 1000000,
-    leveled_log:log(
+    ?STD_LOG(
         p0032,
         [
             Timings#pcl_fetch_timings.sample_count,
@@ -586,7 +588,7 @@ handle_cast({report_stats, sst_fetch}, State) ->
                     os:timestamp(),
                     Timings#sst_fetch_timings.sample_start_time
                 ) div 1000000,
-            leveled_log:log(
+            ?STD_LOG(
                 sst12,
                 [
                     Level,
@@ -612,7 +614,7 @@ handle_cast({report_stats, cdb_get}, State) ->
             os:timestamp(),
             Timings#cdb_get_timings.sample_start_time
         ) div 1000000,
-    leveled_log:log(
+    ?STD_LOG(
         cdb19,
         [
             Timings#cdb_get_timings.sample_count,

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -75,7 +75,7 @@ clerk_new(Owner, RootPath, OptsSST) ->
             []
         ),
     ok = gen_server:call(Pid, {load, Owner, RootPath}, infinity),
-    leveled_log:log(pc001, [Pid, Owner]),
+    ?STD_LOG(pc001, [Pid, Owner]),
     {ok, Pid}.
 
 -spec clerk_prompt(pid()) -> ok.
@@ -138,7 +138,7 @@ handle_cast(
     {ManifestSQN, Deletions} =
         handle_work(Work, RP, State#state.sst_options, PCL),
     PDs = dict:store(ManifestSQN, Deletions, State#state.pending_deletions),
-    leveled_log:log(pc022, [ManifestSQN]),
+    ?STD_LOG(pc022, [ManifestSQN]),
     {noreply, State#state{pending_deletions = PDs}, ?MIN_TIMEOUT};
 handle_cast(
     {prompt_deletions, ManifestSQN}, State = #state{owner = PCL}
@@ -175,7 +175,7 @@ handle_info(timeout, State = #state{owner = PCL}) when is_pid(PCL) ->
     {noreply, State, ?MAX_TIMEOUT}.
 
 terminate(Reason, _State) ->
-    leveled_log:log(pc005, [self(), Reason]).
+    ?STD_LOG(pc005, [self(), Reason]).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -196,13 +196,13 @@ handle_work(
 ) ->
     {UpdManifest, EntriesToDelete} =
         merge(SrcLevel, Manifest, RootPath, SSTOpts),
-    leveled_log:log(pc007, []),
+    ?STD_LOG(pc007, []),
     SWMC = os:timestamp(),
     ok = leveled_penciller:pcl_manifestchange(Owner, UpdManifest),
-    leveled_log:log_timer(pc017, [], SWMC),
+    ?TMR_LOG(pc017, [], SWMC),
     SWSM = os:timestamp(),
     ok = leveled_pmanifest:save_manifest(UpdManifest, RootPath),
-    leveled_log:log_timer(pc018, [], SWSM),
+    ?TMR_LOG(pc018, [], SWSM),
     {leveled_pmanifest:get_manifest_sqn(UpdManifest), EntriesToDelete}.
 
 -spec merge(
@@ -217,14 +217,8 @@ merge(SrcLevel, Manifest, RootPath, OptsSST) ->
         {0, 0, undefined, 0, 0, 0, 0} ->
             ok;
         {FCnt, MnMem, {MaxFN, MaxP, MaxMem}, MnHBS, MnHS, MnLHS, MnBVHS} ->
-            leveled_log:log(
-                pc023,
-                [SrcLevel + 1, FCnt, MnMem, MaxFN, MaxP, MaxMem]
-            ),
-            leveled_log:log(
-                pc025,
-                [SrcLevel + 1, FCnt, MnHBS, MnHS, MnLHS, MnBVHS]
-            )
+            ?STD_LOG(pc023, [SrcLevel + 1, FCnt, MnMem, MaxFN, MaxP, MaxMem]),
+            ?STD_LOG(pc025, [SrcLevel + 1, FCnt, MnHBS, MnHS, MnLHS, MnBVHS])
     end,
     SelectMethod =
         case rand:uniform(100) of
@@ -244,14 +238,11 @@ merge(SrcLevel, Manifest, RootPath, OptsSST) ->
             leveled_pmanifest:entry_endkey(Src)
         ),
     Candidates = length(SinkList),
-    leveled_log:log(pc008, [SrcLevel, Candidates]),
+    ?STD_LOG(pc008, [SrcLevel, Candidates]),
     case Candidates of
         0 ->
             NewLevel = SrcLevel + 1,
-            leveled_log:log(
-                pc009,
-                [leveled_pmanifest:entry_filename(Src), NewLevel]
-            ),
+            ?STD_LOG(pc009, [leveled_pmanifest:entry_filename(Src), NewLevel]),
             leveled_sst:sst_switchlevels(
                 leveled_pmanifest:entry_owner(Src),
                 NewLevel
@@ -293,7 +284,7 @@ notify_deletions([Head | Tail], Penciller) ->
 %%
 %% SrcLevel is the level of the src sst file, the sink should be srcLevel + 1
 perform_merge(Manifest, Src, SinkList, SrcLevel, RootPath, NewSQN, OptsSST) ->
-    leveled_log:log(pc010, [leveled_pmanifest:entry_filename(Src), NewSQN]),
+    ?STD_LOG(pc010, [leveled_pmanifest:entry_filename(Src), NewSQN]),
     SrcList = [{next, Src, all}],
     MaxSQN =
         leveled_sst:sst_getmaxsequencenumber(
@@ -360,7 +351,7 @@ merge_limit(SrcLevel, SinkListLength, MMB) when
     infinity;
 merge_limit(SrcLevel, SinkListLength, MMB) when is_integer(MMB) ->
     AdditionsLimit = max(1, MMB div 2),
-    leveled_log:log(pc026, [SrcLevel + 1, SinkListLength, AdditionsLimit]),
+    ?STD_LOG(pc026, [SrcLevel + 1, SinkListLength, AdditionsLimit]),
     AdditionsLimit.
 
 -type merge_maybe_expanded_pointer() ::
@@ -390,14 +381,14 @@ merge_limit(SrcLevel, SinkListLength, MMB) when is_integer(MMB) ->
 do_merge(
     [], [], SinkLevel, _SinkB, _RP, NewSQN, _MaxSQN, _Opts, Additions, _Max
 ) ->
-    leveled_log:log(pc011, [NewSQN, SinkLevel, length(Additions), full]),
+    ?STD_LOG(pc011, [NewSQN, SinkLevel, length(Additions), full]),
     {lists:reverse(Additions), [], []};
 do_merge(
     KL1, KL2, SinkLevel, SinkB, RP, NewSQN, MaxSQN, OptsSST, Additions, Max
 ) when
     length(Additions) >= Max
 ->
-    leveled_log:log(pc011, [NewSQN, SinkLevel, length(Additions), partial]),
+    ?STD_LOG(pc011, [NewSQN, SinkLevel, length(Additions), partial]),
     FNSrc =
         leveled_penciller:sst_filename(
             NewSQN, SinkLevel - 1, 1
@@ -434,7 +425,7 @@ do_merge(
         leveled_penciller:sst_filename(
             NewSQN, SinkLevel, length(Additions)
         ),
-    leveled_log:log(pc012, [NewSQN, FileName, SinkB]),
+    ?STD_LOG(pc012, [NewSQN, FileName, SinkB]),
     TS1 = os:timestamp(),
     NewMerge =
         leveled_sst:sst_newmerge(
@@ -456,7 +447,7 @@ do_merge(
     ).
 
 add_entry(empty, FileName, _TS1, Additions) ->
-    leveled_log:log(pc013, [FileName]),
+    ?STD_LOG(pc013, [FileName]),
     {Additions, [], []};
 add_entry({ok, Pid, Reply, Bloom}, FileName, TS1, Additions) ->
     {{KL1Rem, KL2Rem}, SmallestKey, HighestKey} = Reply,
@@ -464,7 +455,7 @@ add_entry({ok, Pid, Reply, Bloom}, FileName, TS1, Additions) ->
         leveled_pmanifest:new_entry(
             SmallestKey, HighestKey, Pid, FileName, Bloom
         ),
-    leveled_log:log_timer(pc015, [], TS1),
+    ?TMR_LOG(pc015, [], TS1),
     {[Entry | Additions], KL1Rem, KL2Rem}.
 
 -spec split_unexpanded_files(
@@ -507,7 +498,7 @@ grooming_scorer([ME | MEs]) ->
     InitTombCount =
         leveled_sst:sst_gettombcount(leveled_pmanifest:entry_owner(ME)),
     {HighestTC, BestME} = grooming_scorer(InitTombCount, ME, MEs),
-    leveled_log:log(pc024, [HighestTC]),
+    ?STD_LOG(pc024, [HighestTC]),
     BestME.
 
 grooming_scorer(HighestTC, BestME, []) ->
@@ -531,7 +522,7 @@ return_deletions(ManifestSQN, PendingDeletionD) ->
     %
     % So this is now allowed to crash again
     PendingDeletions = dict:fetch(ManifestSQN, PendingDeletionD),
-    leveled_log:log(pc021, [ManifestSQN]),
+    ?STD_LOG(pc021, [ManifestSQN]),
     {PendingDeletions, dict:erase(ManifestSQN, PendingDeletionD)}.
 
 %%%============================================================================

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -720,7 +720,7 @@ init([LogOpts, PCLopts]) ->
                 pcl_registersnapshot(
                     SrcPenciller, self(), Query, BookiesMem, LongRunning
                 ),
-            leveled_log:log(p0001, [self()]),
+            ?STD_LOG(p0001, [self()]),
             {ok, State#state{
                 is_snapshot = true,
                 clerk = undefined,
@@ -749,21 +749,18 @@ handle_call(
 
     L0Pending = State#state.levelzero_pending,
     WorkBacklog = State#state.work_backlog,
-    CacheAlreadyFull = leveled_pmem:cache_full(State#state.levelzero_cache),
+    CacheFull = leveled_pmem:cache_full(State#state.levelzero_cache),
     L0Size = State#state.levelzero_size,
 
     % The clerk is prompted into action as there may be a L0 write required
     ok = leveled_pclerk:clerk_prompt(State#state.clerk),
 
-    case L0Pending or WorkBacklog or CacheAlreadyFull of
+    case L0Pending orelse WorkBacklog orelse CacheFull of
         true ->
             % Cannot update the cache, or roll the memory so reply `returned`
             % The Bookie must now retain the lesger cache and try to push the
             % updated cache at a later time
-            leveled_log:log(
-                p0018,
-                [L0Size, L0Pending, WorkBacklog, CacheAlreadyFull]
-            ),
+            ?STD_LOG(p0018, [L0Size, L0Pending, WorkBacklog, CacheFull]),
             {reply, returned, State};
         false ->
             % Return ok as cache has been updated on State and the Bookie
@@ -793,12 +790,8 @@ handle_call(
                             State#state.levelzero_index,
                             length(State#state.levelzero_cache) + 1
                         ),
-                    leveled_log:log_randomtimer(
-                        p0031,
-                        [NewL0Size, true, true, MinSQN, MaxSQN],
-                        SW,
-                        0.1
-                    ),
+                    Subs = [NewL0Size, true, true, MinSQN, MaxSQN],
+                    ?RND_LOG(p0031, Subs, SW, 0.1),
                     {reply, ok, State#state{
                         levelzero_cache = UpdL0Cache,
                         levelzero_size = NewL0Size,
@@ -896,9 +889,7 @@ handle_call(
                 lists:filter(FilterFun, L0AsList)
         end,
 
-    leveled_log:log_randomtimer(
-        p0037, [State#state.levelzero_size], SW, 0.01
-    ),
+    ?RND_LOG(p0037, [State#state.levelzero_size], SW, 0.01),
 
     %% Rename any reference to loop state that may be used by the function
     %% to be returned - https://github.com/martinsumner/leveled/issues/326
@@ -994,9 +985,7 @@ handle_call(
                         State#state.levelzero_cache,
                         LM1Cache
                     ),
-                leveled_log:log_randomtimer(
-                    p0037, [State#state.levelzero_size], SW, 0.01
-                ),
+                ?RND_LOG(p0037, [State#state.levelzero_size], SW, 0.01),
                 {
                     #state{
                         levelzero_astree = L0AsTree,
@@ -1076,7 +1065,7 @@ handle_call(
     % The penciller should close each file in the manifest, and call a close
     % on the clerk.
     ok = leveled_pclerk:clerk_close(Clerk),
-    leveled_log:log(p0008, [close]),
+    ?STD_LOG(p0008, [close]),
     L0Left = State#state.levelzero_size > 0,
     case (not State#state.levelzero_pending and L0Left) of
         true ->
@@ -1092,7 +1081,7 @@ handle_call(
                 ),
             ok = leveled_sst:sst_close(Constructor);
         false ->
-            leveled_log:log(p0010, [State#state.levelzero_size])
+            ?STD_LOG(p0010, [State#state.levelzero_size])
     end,
     gen_server:cast(self(), {maybe_defer_shutdown, close, From}),
     {noreply, State};
@@ -1101,7 +1090,7 @@ handle_call(
 ) when
     ?IS_DEF(Clerk)
 ->
-    leveled_log:log(p0030, []),
+    ?STD_LOG(p0030, []),
     ok = leveled_pclerk:clerk_close(Clerk),
     gen_server:cast(self(), {maybe_defer_shutdown, doom, From}),
     {noreply, State};
@@ -1151,7 +1140,7 @@ handle_cast(
 ->
     NewManSQN = leveled_pmanifest:get_manifest_sqn(Manifest),
     OldManSQN = leveled_pmanifest:get_manifest_sqn(OldManifest),
-    leveled_log:log(p0041, [OldManSQN, NewManSQN]),
+    ?STD_LOG(p0041, [OldManSQN, NewManSQN]),
     % Only safe to update the manifest if the SQN increments
     if
         NewManSQN > OldManSQN ->
@@ -1182,7 +1171,7 @@ handle_cast(
 ->
     Manifest0 =
         leveled_pmanifest:release_snapshot(Manifest, Snapshot),
-    leveled_log:log(p0003, [Snapshot]),
+    ?STD_LOG(p0003, [Snapshot]),
     {noreply, State#state{manifest = Manifest0}};
 handle_cast(
     {confirm_delete, PDFN, FilePid}, State = #state{is_snapshot = Snap}
@@ -1205,7 +1194,7 @@ handle_cast(
     % will be cleared from pending using the maybe_release boolean
     case leveled_pmanifest:ready_to_delete(State#state.manifest, PDFN) of
         true ->
-            leveled_log:log(p0005, [PDFN]),
+            ?STD_LOG(p0005, [PDFN]),
             ok = leveled_sst:sst_deleteconfirmed(FilePid),
             case State#state.work_ongoing of
                 true ->
@@ -1242,7 +1231,7 @@ handle_cast(
 ) when
     ?IS_DEF(Man), ?IS_DEF(L0C), ?IS_DEF(Clerk)
 ->
-    leveled_log:log(p0029, []),
+    ?STD_LOG(p0029, []),
     ManEntry = leveled_pmanifest:new_entry(StartKey, EndKey, L0C, FN, Bloom),
     ManifestSQN = leveled_pmanifest:get_manifest_sqn(Man) + 1,
     UpdMan =
@@ -1320,7 +1309,7 @@ handle_cast(
                     % L0 work to do, or because the backlog has grown beyond
                     % tolerance
                     Backlog = WC >= ?WORKQUEUE_BACKLOG_TOLERANCE,
-                    leveled_log:log(p0024, [WC, Backlog, L0Full]),
+                    ?STD_LOG(p0024, [WC, Backlog, L0Full]),
                     [TL | _Tail] = WL,
                     ok = leveled_pclerk:clerk_push(Clerk, {TL, Man}),
                     {noreply, State#state{
@@ -1375,7 +1364,7 @@ handle_cast(
             % complete_shutdown cast is sent
             case State#state.shutdown_loops of
                 LoopCount when LoopCount > 0 ->
-                    leveled_log:log(p0042, [N]),
+                    ?STD_LOG(p0042, [N]),
                     timer:sleep(?SHUTDOWN_PAUSE div ?SHUTDOWN_LOOPS),
                     gen_server:cast(
                         self(), {maybe_defer_shutdown, ShutdownType, From}
@@ -1422,9 +1411,9 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(Reason, _State = #state{is_snapshot = Snap}) when Snap == true ->
-    leveled_log:log(p0007, [Reason]);
+    ?STD_LOG(p0007, [Reason]);
 terminate(Reason, _State) ->
-    leveled_log:log(p0011, [Reason]).
+    ?STD_LOG(p0011, [Reason]).
 
 format_status(Status) ->
     case maps:get(reason, Status, normal) of
@@ -1516,15 +1505,15 @@ start_from_file(
     SQNFun = fun leveled_sst:sst_getmaxsequencenumber/1,
     {MaxSQN, Manifest1, FileList} =
         leveled_pmanifest:load_manifest(Manifest0, OpenFun, SQNFun),
-    leveled_log:log(p0014, [MaxSQN]),
+    ?STD_LOG(p0014, [MaxSQN]),
     ManSQN = leveled_pmanifest:get_manifest_sqn(Manifest1),
-    leveled_log:log(p0035, [ManSQN]),
+    ?STD_LOG(p0035, [ManSQN]),
     %% Find any L0 files
     L0FN = sst_filename(ManSQN + 1, 0, 0),
     {{InitManifest, InitLedgerSQN, InitPersistSQN}, FileList0} =
         case filelib:is_file(filename:join(sst_rootpath(RootPath), L0FN)) of
             true ->
-                leveled_log:log(p0015, [L0FN]),
+                ?STD_LOG(p0015, [L0FN]),
                 L0Open =
                     leveled_sst:sst_open(
                         sst_rootpath(RootPath), L0FN, OptsSST, 0
@@ -1539,14 +1528,14 @@ start_from_file(
                     leveled_pmanifest:insert_manifest_entry(
                         Manifest1, ManSQN + 1, 0, L0Entry
                     ),
-                leveled_log:log(p0016, [L0SQN]),
+                ?STD_LOG(p0016, [L0SQN]),
                 LedgerSQN = max(MaxSQN, L0SQN),
                 {
                     {Manifest2, LedgerSQN, LedgerSQN},
                     [L0FN | FileList]
                 };
             false ->
-                leveled_log:log(p0017, []),
+                ?STD_LOG(p0017, []),
                 {{Manifest1, MaxSQN, MaxSQN}, FileList}
         end,
     ok = archive_files(RootPath, FileList0),
@@ -1622,7 +1611,7 @@ archive_files(RootPath, UsedFileList) ->
                         true ->
                             UnusedFiles;
                         false ->
-                            leveled_log:log(p0040, [FN0]),
+                            ?STD_LOG(p0040, [FN0]),
                             [FN0 | UnusedFiles]
                     end;
                 _ ->
@@ -1697,7 +1686,7 @@ maybe_cache_too_big(NewL0Size, L0MaxSize, CoinToss) ->
 roll_memory(NextManSQN, LedgerSQN, RootPath, none, CL, SSTOpts, false) ->
     L0Path = sst_rootpath(RootPath),
     L0FN = sst_filename(NextManSQN, 0, 0),
-    leveled_log:log(p0019, [L0FN, LedgerSQN]),
+    ?STD_LOG(p0019, [L0FN, LedgerSQN]),
     PCL = self(),
     FetchFun =
         fun(Slot, ReturnFun) -> pcl_fetchlevelzero(PCL, Slot, ReturnFun) end,
@@ -1823,10 +1812,10 @@ log_slowfetch(T0, R, PID, Level, FetchTolerance) ->
         {T, R} when T < FetchTolerance ->
             R;
         {T, not_present} ->
-            leveled_log:log(pc016, [PID, T, Level, not_present]),
+            ?STD_LOG(pc016, [PID, T, Level, not_present]),
             not_present;
         {T, R} ->
-            leveled_log:log(pc016, [PID, T, Level, found]),
+            ?STD_LOG(pc016, [PID, T, Level, found]),
             R
     end.
 

--- a/src/leveled_pmanifest.erl
+++ b/src/leveled_pmanifest.erl
@@ -392,7 +392,7 @@ replace_manifest_entry(Manifest, ManSQN, LevelIdx, Removals, Additions) ->
     {UpdBlooms, StrippedAdditions} =
         update_blooms(Removals, Additions, Manifest#manifest.blooms),
     UpdLevel = replace_entry(LevelIdx, Level, Removals, StrippedAdditions),
-    leveled_log:log(pc019, ["insert", LevelIdx, UpdLevel]),
+    ?STD_LOG(pc019, ["insert", LevelIdx, UpdLevel]),
     PendingDeletes =
         update_pendingdeletes(
             ManSQN, Removals, Manifest#manifest.pending_deletes
@@ -430,7 +430,7 @@ insert_manifest_entry(Manifest, ManSQN, LevelIdx, Entry) ->
     {UpdBlooms, UpdEntry} =
         update_blooms([], Entry, Manifest#manifest.blooms),
     UpdLevel = add_entry(LevelIdx, Level, UpdEntry),
-    leveled_log:log(pc019, ["insert", LevelIdx, UpdLevel]),
+    ?STD_LOG(pc019, ["insert", LevelIdx, UpdLevel]),
     Basement = max(LevelIdx, Manifest#manifest.basement),
     Manifest#manifest{
         levels = array:set(LevelIdx, UpdLevel, Levels),
@@ -450,7 +450,7 @@ remove_manifest_entry(Manifest, ManSQN, LevelIdx, Entry) ->
     {UpdBlooms, []} =
         update_blooms(Entry, [], Manifest#manifest.blooms),
     UpdLevel = remove_entry(LevelIdx, Level, Entry),
-    leveled_log:log(pc019, ["remove", LevelIdx, UpdLevel]),
+    ?STD_LOG(pc019, ["remove", LevelIdx, UpdLevel]),
     PendingDeletes =
         update_pendingdeletes(
             ManSQN, Entry, Manifest#manifest.pending_deletes
@@ -659,7 +659,7 @@ release_snapshot(Manifest, Pid) ->
                 _ ->
                     case seconds_now() > (ST + TO) of
                         true ->
-                            leveled_log:log(p0038, [P, SQN, ST, TO]),
+                            ?STD_LOG(p0038, [P, SQN, ST, TO]),
                             {Acc, MinSQN, Found};
                         false ->
                             {[{P, SQN, ST, TO} | Acc], min(SQN, MinSQN), Found}
@@ -674,7 +674,7 @@ release_snapshot(Manifest, Pid) ->
         ),
     case Hit of
         false ->
-            leveled_log:log(p0039, [Pid, length(SnapList0), MinSnapSQN]);
+            ?STD_LOG(p0039, [Pid, length(SnapList0), MinSnapSQN]);
         true ->
             ok
     end,
@@ -682,7 +682,7 @@ release_snapshot(Manifest, Pid) ->
         [] ->
             Manifest#manifest{snapshots = SnapList0, min_snapshot_sqn = 0};
         _ when is_integer(MinSnapSQN) ->
-            leveled_log:log(p0004, [SnapList0]),
+            ?STD_LOG(p0004, [SnapList0]),
             Manifest#manifest{
                 snapshots = SnapList0, min_snapshot_sqn = MinSnapSQN
             }
@@ -1177,7 +1177,7 @@ filepath(RootPath, NewMSN, pending_manifest) ->
         integer_to_list(NewMSN) ++ "." ++ ?PENDING_FILEX.
 
 open_manifestfile(_RootPath, L) when L == [] orelse L == [0] ->
-    leveled_log:log(p0013, []),
+    ?STD_LOG(p0013, []),
     new_manifest();
 open_manifestfile(RootPath, [TopManSQN | Rest]) ->
     CurrManFile = filepath(RootPath, TopManSQN, current_manifest),
@@ -1185,14 +1185,14 @@ open_manifestfile(RootPath, [TopManSQN | Rest]) ->
     <<CRC:32/integer, BinaryOfTerm/binary>> = FileBin,
     case erlang:crc32(BinaryOfTerm) of
         CRC ->
-            leveled_log:log(p0012, [TopManSQN]),
+            ?STD_LOG(p0012, [TopManSQN]),
             Manifest = binary_to_term(BinaryOfTerm),
             Manifest#manifest{
                 pending_deletes = new_pending_deletions(),
                 blooms = new_blooms()
             };
         _ ->
-            leveled_log:log(p0033, [CurrManFile, "crc wonky"]),
+            ?STD_LOG(p0033, [CurrManFile, "crc wonky"]),
             open_manifestfile(RootPath, Rest)
     end.
 

--- a/src/leveled_pmem.erl
+++ b/src/leveled_pmem.erl
@@ -167,7 +167,7 @@ to_list(Slots, FetchFun) ->
         [],
         SlotList
     ),
-    leveled_log:log_timer(pm002, [length(FullList)], SW),
+    ?TMR_LOG(pm002, [length(FullList)], SW),
     FullList.
 
 -spec check_levelzero(tuple(), list(integer()), list()) ->

--- a/src/leveled_runner.erl
+++ b/src/leveled_runner.erl
@@ -434,7 +434,7 @@ foldobjects_allkeys(SnapFun, Tag, FoldObjectsFun, sqn_order) ->
                                     Acc
                             end
                         end,
-                    leveled_log:log(r0001, [length(BatchAcc)]),
+                    ?STD_LOG(r0001, [length(BatchAcc)]),
                     lists:foldr(ObjFun, ObjAcc, BatchAcc)
                 end,
 
@@ -539,10 +539,10 @@ get_nextbucket(NextBucket, NextKey, Tag, LedgerSnapshot, BKList, {C, L}) ->
         ),
     case R of
         {1, null} ->
-            leveled_log:log(b0008, []),
+            ?STD_LOG(b0008, []),
             BKList;
         {0, {{B, K}, _V}} when is_binary(B); is_tuple(B) ->
-            leveled_log:log(b0009, [B]),
+            ?STD_LOG(b0009, [B]),
             get_nextbucket(
                 leveled_codec:next_key(B),
                 null,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -645,9 +645,7 @@ starting(
             Level
         ),
     Summary = UpdState#state.summary,
-    leveled_log:log_timer(
-        sst08, [ActualFilename, Level, Summary#summary.max_sqn], SW
-    ),
+    ?TMR_LOG(sst08, [ActualFilename, Level, Summary#summary.max_sqn], SW),
     erlang:send_after(?STARTUP_TIMEOUT, self(), start_complete),
     {next_state, reader,
         UpdState#state{
@@ -745,10 +743,8 @@ starting(cast, complete_l0startup, State) ->
     Summary = UpdState#state.summary,
     Time4 = timer:now_diff(os:timestamp(), SW4),
 
-    leveled_log:log_timer(
-        sst08, [ActualFilename, 0, Summary#summary.max_sqn], SW0
-    ),
-    leveled_log:log(sst11, [Time0, Time1, Time2, Time3, Time4]),
+    ?TMR_LOG(sst08, [ActualFilename, 0, Summary#summary.max_sqn], SW0),
+    ?STD_LOG(sst11, [Time0, Time1, Time2, Time3, Time4]),
 
     case Penciller of
         undefined ->
@@ -888,7 +884,7 @@ reader({call, From}, get_maxsequencenumber, State) ->
     Summary = State#state.summary,
     {keep_state_and_data, [{reply, From, Summary#summary.max_sqn}]};
 reader({call, From}, {set_for_delete, Penciller}, State) ->
-    leveled_log:log(sst06, [State#state.filename]),
+    ?STD_LOG(sst06, [State#state.filename]),
     {next_state, delete_pending, State#state{penciller = Penciller}, [
         {reply, From, ok}, ?DELETE_TIMEOUT
     ]};
@@ -928,7 +924,7 @@ reader(info, bic_complete, State) ->
     % The block index cache is complete, so the memory footprint should be
     % relatively stable from this point.  Hibernate to help minimise
     % fragmentation
-    leveled_log:log(sst14, [State#state.filename]),
+    ?STD_LOG(sst14, [State#state.filename]),
     {keep_state_and_data, [hibernate]};
 reader(
     info,
@@ -1019,7 +1015,7 @@ delete_pending(
     close,
     State = #state{read_state = RS}
 ) when ?IS_DEF(RS) ->
-    leveled_log:log(sst07, [State#state.filename]),
+    ?STD_LOG(sst07, [State#state.filename]),
     ok = file:close(RS#read_state.handle),
     ok =
         file:delete(
@@ -1031,7 +1027,7 @@ delete_pending(
     close,
     State = #state{read_state = RS}
 ) when ?IS_DEF(RS) ->
-    leveled_log:log(sst07, [State#state.filename]),
+    ?STD_LOG(sst07, [State#state.filename]),
     ok = file:close(RS#read_state.handle),
     ok =
         file:delete(
@@ -1079,7 +1075,7 @@ handle_update_blockindex_cache(
 terminate(normal, delete_pending, _State) ->
     ok;
 terminate(Reason, _StateName, State) ->
-    leveled_log:log(sst04, [Reason, State#state.filename]).
+    ?STD_LOG(sst04, [Reason, State#state.filename]).
 
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
@@ -1158,7 +1154,7 @@ expand_list_by_pointer(
     % This can then be further expanded by calling again to
     % expand_list_by_pointer
     SSTPid = leveled_pmanifest:entry_owner(ME),
-    leveled_log:log(sst10, [SSTPid, is_process_alive(SSTPid)]),
+    ?STD_LOG(sst10, [SSTPid, is_process_alive(SSTPid)]),
     ExpPointer = sst_getfilteredrange(SSTPid, StartKey, EndKey, LowLastMod),
     ExpPointer ++ Tail.
 
@@ -1720,7 +1716,7 @@ write_file(
             AltName =
                 filename:join(RootPath, filename:basename(FinalName)) ++
                     ?DISCARD_EXT,
-            leveled_log:log(sst05, [FinalName, AltName]),
+            ?STD_LOG(sst05, [FinalName, AltName]),
             ok = file:rename(filename:join(RootPath, FinalName), AltName);
         false ->
             ok
@@ -1755,16 +1751,15 @@ read_file(Filename, State, LoadPageCache, BIC, Level) ->
             SlotList, Summary#summary.first_key, Summary#summary.last_key
         ),
     UpdSummary = Summary#summary{index = SlotIndex},
-    leveled_log:log(
-        sst03, [Filename, Summary#summary.size, Summary#summary.max_sqn]
-    ),
+    Size = Summary#summary.size,
+    ?STD_LOG(sst03, [Filename, Size, Summary#summary.max_sqn]),
     ReadState =
         #read_state{
             handle = Handle,
             blockindex_cache =
                 case BIC of
                     undefined ->
-                        new_blockindex_cache(Summary#summary.size);
+                        new_blockindex_cache(Size);
                     _ ->
                         BIC
                 end,
@@ -3170,7 +3165,7 @@ crc_check_slot(FullBin) ->
         {CRC32H, CRC32PBL} ->
             {Header, Blocks};
         _ ->
-            leveled_log:log(sst09, []),
+            ?STD_LOG(sst09, []),
             crc_wonky
     end.
 
@@ -3716,7 +3711,7 @@ update_buildtimings(Timings, Stage) ->
 log_buildtimings(no_timing, _LI) ->
     ok;
 log_buildtimings(Timings, LI) ->
-    leveled_log:log(
+    ?STD_LOG(
         sst13,
         [
             Timings#build_timings.fold_toslot,

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -21,6 +21,8 @@
 
 -module(leveled_sstblock).
 
+-include("leveled.hrl").
+
 -define(MAX_SUBBLOCK_SIZE, 1 bsl 16).
 -define(BLOCK_TYPE0, 0).
 % Block is just a list of terms
@@ -375,7 +377,7 @@ check_block(Block, Default, ExtractFun) when byte_size(Block) > 4 ->
         ExtractFun(TermBin)
     catch
         _Exception:Reason ->
-            leveled_log:log(sst15, [Reason]),
+            ?STD_LOG(sst15, [Reason]),
             Default
     end;
 check_block(_Block, Default, _ExtractFun) ->
@@ -702,7 +704,6 @@ serialise_block(Term, none) ->
 -ifdef(TEST).
 
 -include_lib("eunit/include/eunit.hrl").
--include("leveled.hrl").
 
 v1_block_test() ->
     v1_block_tester(lookup, {1, zstd}, 24),

--- a/test/end_to_end/recovery_SUITE.erl
+++ b/test/end_to_end/recovery_SUITE.erl
@@ -64,7 +64,8 @@ replace_everything(_Config) ->
                 {cache_size, 2000},
                 {max_journalobjectcount, JournalObjectCount},
                 {sync_strategy, testutil:sync_strategy()},
-                {reload_strategy, [{?RIAK_TAG, recalc}]}
+                {reload_strategy, [{?RIAK_TAG, recalc}]},
+                {log_level, warning}
             ]
         end,
     {ok, Book1} = leveled_bookie:book_start(BookOpts(StdJournalCount)),

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -98,7 +98,19 @@
 }).
 
 init_per_suite(Config) ->
-    LogTemplate = [time, " log_level=", level, " ", msg, "\n"],
+    LogTemplate =
+        [
+            time,
+            " [",
+            level,
+            "] ",
+            {pid, [pid, "@"], []},
+            {mfa, [mfa, ":"], []},
+            {line, [line, ":"], []},
+            " ",
+            msg,
+            "\n"
+        ],
     LogFormatter =
         {
             logger_formatter,
@@ -118,21 +130,12 @@ init_per_suite(Config) ->
                 }
         },
 
-    LogFilter =
-        fun(LogEvent, LogType) ->
-            Meta = maps:get(meta, LogEvent),
-            case maps:get(log_type, Meta, not_found) of
-                LogType ->
-                    LogEvent;
-                _ ->
-                    ignore
-            end
-        end,
+    LogFilter = {fun logger_filters:domain/2, {log, sub, [backend]}},
 
     ok = logger:add_handler(logfile, logger_std_h, LogConfig),
     ok = logger:set_handler_config(logfile, formatter, LogFormatter),
     ok = logger:set_handler_config(logfile, level, info),
-    ok = logger:add_handler_filter(logfile, type_filter, {LogFilter, backend}),
+    ok = logger:add_handler_filter(logfile, domain_filter, LogFilter),
 
     ok = logger:set_handler_config(default, level, notice),
     ok = logger:set_handler_config(cth_log_redirect, level, notice),


### PR DESCRIPTION
* Switch to using domain filtering not log_type

This looks like it is a more correct way of doing this.

Given we have no agreed hierarchy as part of OpenRiak, will use [backend, leveled] as a start.

* Align log format with Erlang standards

The leveled_log code is not aligned well with the expectations of riak kernel logger.  In particular log function calls were centralised, and so MFA metadata is irrelevant.

This change implements the log function calls as a macro, so that the should_i_log logic cna be maintained, but MFA metadata will be correctly present in the log.  It also ends the practice of adding the pid() directly to the log, instead relying on the metadata

* Format via erlfmt

* ensure logger:allow/2 is called

Will be filtered by global and ?MODULE log filters.

Outstanding code coverage issue caused by detecting `false` branch when macro is substituted over multiple lines.

* Add missing space to logs with no db_id

* Coverage

code coverage is an issue with the switch to macros for logging.  Not every log line will have a `false` from the log allow - and that will fail code coverage ... but only if the log covers multiple lines.

Most logs covering multiple lines, do do needlessly.  So avoid the code coverage issue by making those logs single line.

* Update include/leveled.hrl



* Updates post review

* Remove unused get_log

Code uses get_loglevel/1

---------